### PR TITLE
Feat/connect #37

### DIFF
--- a/src/components/ContainerLarge.tsx
+++ b/src/components/ContainerLarge.tsx
@@ -65,7 +65,7 @@ const ContainerLarge = ({isLoggedIn}:{isLoggedIn:boolean}) => {
                     <img src={icMyPage} width={22} />
                     <IconTextDiv fontSize={'10px'}>마이페이지</IconTextDiv>
                 </IconDiv>
-                <IconDiv>
+                <IconDiv onClick={()=>navigate('/change')}>
                     <Img src={imgTicket} height={18} />
                     <IconTextDiv fontSize={'10px'}>충전/환전</IconTextDiv>
                 </IconDiv>

--- a/src/pages/raffleUpload/RaffleUploadPage.tsx
+++ b/src/pages/raffleUpload/RaffleUploadPage.tsx
@@ -10,15 +10,13 @@ import UploadModal from "./components/UploadModal";
 const RaffleUploadPage = () => {
     const { openModal } = useModalContext();
 
-    const handleSubmit = (e:React.FormEvent<HTMLFormElement>) => {
-        // 제출 일단 막아두기
+    const handleSubmit = (e:React.FormEvent<HTMLInputElement>) => {
         e.preventDefault();
-        // 모달 연결
         openModal(({ onClose }) => <UploadModal onClose={onClose} />);
     };
 
     return (
-        <UploadForm onSubmit={handleSubmit}>
+        <UploadForm>
             <div>
                 <BigTitle>상품 정보</BigTitle>
                 <ItemInfoContainer>
@@ -68,12 +66,12 @@ const RaffleUploadPage = () => {
                         </div>
                         <div>
                             <TitleSpan>상태</TitleSpan>
-                            <ConditionBtn>미개봉</ConditionBtn>
-                            <ConditionBtn>새상품</ConditionBtn>
-                            <ConditionBtn>상태</ConditionBtn>
-                            <ConditionBtn>상</ConditionBtn>
-                            <ConditionBtn>중</ConditionBtn>
-                            <ConditionBtn>하</ConditionBtn>
+                            <ConditionBtn type="button">미개봉</ConditionBtn>
+                            <ConditionBtn type="button">새상품</ConditionBtn>
+                            <ConditionBtn type="button">상태</ConditionBtn>
+                            <ConditionBtn type="button">상</ConditionBtn>
+                            <ConditionBtn type="button">중</ConditionBtn>
+                            <ConditionBtn type="button">하</ConditionBtn>
                         </div>
                         <TextareaDiv>
                             <TitleSpan>설명</TitleSpan>
@@ -89,10 +87,10 @@ const RaffleUploadPage = () => {
                 <SetConditionContainer>
                     <SetConditionBox>
                         <TitleSpan2>응모 티켓 개수</TitleSpan2>
-                            <ConditionBtn>1개</ConditionBtn>
-                            <ConditionBtn>2개</ConditionBtn>
-                            <ConditionBtn>3개</ConditionBtn>
-                            <ConditionBtn>직접입력</ConditionBtn>
+                            <ConditionBtn type="button">1개</ConditionBtn>
+                            <ConditionBtn type="button">2개</ConditionBtn>
+                            <ConditionBtn type="button">3개</ConditionBtn>
+                            <ConditionBtn type="button">직접입력</ConditionBtn>
                     </SetConditionBox>
                     <SetConditionBox>
                         <TitleSpan2>최소 마감 티켓 개수</TitleSpan2>
@@ -113,7 +111,7 @@ const RaffleUploadPage = () => {
                     </SetConditionBox>
                 </SetConditionContainer>
             </div>
-            <SubmitBtn type="submit" value={"업로드"} />
+            <SubmitBtn type="submit" value={"업로드"} onClick={handleSubmit} />
         </UploadForm>
     );
 };

--- a/src/pages/raffleUpload/RaffleUploadPage.tsx
+++ b/src/pages/raffleUpload/RaffleUploadPage.tsx
@@ -1,12 +1,24 @@
 import styled from "styled-components";
-import BigTitle from "../components/BigTitle";
-import imgUpload from "../assets/imgUpload.svg";
-import icArrow from "../assets/icSelectArrow.svg";
-import imgArrow from "../assets/imgSelectArrow.png";
+import BigTitle from "../../components/BigTitle";
+import imgUpload from "../../assets/imgUpload.svg";
+import icArrow from "../../assets/icSelectArrow.svg";
+import imgArrow from "../../assets/imgSelectArrow.png";
+import React, { ReactElement } from "react";
+import { useModalContext } from "../../components/Modal/context/ModalContext";
+import UploadModal from "./components/UploadModal";
 
 const RaffleUploadPage = () => {
+    const { openModal } = useModalContext();
+
+    const handleSubmit = (e:React.FormEvent<HTMLFormElement>) => {
+        // 제출 일단 막아두기
+        e.preventDefault();
+        // 모달 연결
+        openModal(({ onClose }) => <UploadModal onClose={onClose} />);
+    };
+
     return (
-        <UploadForm>
+        <UploadForm onSubmit={handleSubmit}>
             <div>
                 <BigTitle>상품 정보</BigTitle>
                 <ItemInfoContainer>

--- a/src/pages/raffleUpload/RaffleUploadPage.tsx
+++ b/src/pages/raffleUpload/RaffleUploadPage.tsx
@@ -6,9 +6,14 @@ import imgArrow from "../../assets/imgSelectArrow.png";
 import React, { ReactElement } from "react";
 import { useModalContext } from "../../components/Modal/context/ModalContext";
 import UploadModal from "./components/UploadModal";
+import TicketModal from "./components/TicketModal";
 
 const RaffleUploadPage = () => {
     const { openModal } = useModalContext();
+
+    const handleTicketModal = () => {
+        openModal(({ onClose }) => <TicketModal onClose={onClose} />);
+    };
 
     const handleSubmit = (e:React.FormEvent<HTMLInputElement>) => {
         e.preventDefault();
@@ -90,7 +95,10 @@ const RaffleUploadPage = () => {
                             <ConditionBtn type="button">1개</ConditionBtn>
                             <ConditionBtn type="button">2개</ConditionBtn>
                             <ConditionBtn type="button">3개</ConditionBtn>
-                            <ConditionBtn type="button">직접입력</ConditionBtn>
+                            <ConditionBtn
+                            type="button"
+                            onClick={handleTicketModal}
+                            >직접입력</ConditionBtn>
                     </SetConditionBox>
                     <SetConditionBox>
                         <TitleSpan2>최소 마감 티켓 개수</TitleSpan2>

--- a/src/pages/raffleUpload/components/TicketModal.tsx
+++ b/src/pages/raffleUpload/components/TicketModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from '../Modal';
+import Modal from '../../../components/Modal/Modal';
 import styled from 'styled-components';
 import vector from '../../../assets/Vector.png';
 
@@ -14,7 +14,7 @@ const TicketModal: React.FC<ModalProps> = ({ onClose }) => {
         <Img src={vector} />
         <Title>티켓 개수 직접 입력하기</Title>
         <Input placeholder="개" />
-        <Button>설정하기</Button>
+        <Button onClick={onClose}>설정하기</Button>
       </Container>
     </Modal>
   );

--- a/src/pages/raffleUpload/components/UploadModal.tsx
+++ b/src/pages/raffleUpload/components/UploadModal.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import Modal from '../Modal';
+import Modal from '../../../components/Modal/Modal';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 
 interface ModalProps {
   onClose: () => void;
 }
 
 const UploadModal: React.FC<ModalProps> = ({ onClose }) => {
+  const navigate = useNavigate();
   return (
     <Modal onClose={onClose}>
       <Container>
         <Box />
         <Title>로지텍 무소음 마우스</Title>
         <Short>해당 래플을 업로드하시겠습니까?</Short>
-        <Button>업로드</Button>
+        <Button onClick={()=>navigate('/')}>업로드</Button>
       </Container>
     </Modal>
   );

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -4,7 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import RootLayout from '../layout/RootLayout';
 import ChargePage from '../pages/charge/chargePage';
 import ModalProvider from '../components/Modal/context/ModalProvider';
-import RaffleUploadPage from '../pages/raffleUpload/RaffleUploadPage';
+import RaffleUploadPage from '../pages/raffleUpload/raffleUploadPage';
 import WriteReview from '../pages/writeReview/writeReview';
 import AddressSetPage from '../pages/address/addressSetPage';
 import SetOpenInfoPage from '../pages/setOpenInfo/setOpenInfoPage';

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -4,7 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import RootLayout from '../layout/RootLayout';
 import ChargePage from '../pages/charge/chargePage';
 import ModalProvider from '../components/Modal/context/ModalProvider';
-import RaffleUploadPage from '../pages/RaffleUploadPage';
+import RaffleUploadPage from '../pages/raffleUpload/RaffleUploadPage';
 import WriteReview from '../pages/writeReview/writeReview';
 import AddressSetPage from '../pages/address/addressSetPage';
 import SetOpenInfoPage from '../pages/setOpenInfo/setOpenInfoPage';


### PR DESCRIPTION
## 📑 이슈 번호
#37 

## ✨️ 작업 내용
- 헤더 컴포넌트: 티켓 충전/환전 페이지 연결
- 래플 업로드 페이지: 폴더구조 및 파일명 수정
- 래플 업로드 페이지: 티켓 개수 직접 입력 모달 연결
- 래플 업로드 페이지: 업로드 버튼, 업로드 모달, 홈페이지 페이지 이동 연결
- 래플 업로드 페이지: form submit 동작 제어

## 💙 코멘트
페이지 연결 위해서 완성하신 다른 페이지들 develop에 병합 부탁드립니다.


## 📸 구현 결과
