### PR TITLE
Feat: 로그인 접근 제한 기능 추가

### DIFF
--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -23,6 +23,7 @@ import MyReview from '../pages/mypage/MyReview';
 import Payment from '../pages/mypage/Payment';
 import WinnerPage from '../pages/winner/winnerPage';
 import UserProfilePage from '../pages/mypage/UserProfilePage';
+import PrivateRoute from '../services/PrivateRoute';
 
 const router = createBrowserRouter([
   {
@@ -36,6 +37,78 @@ const router = createBrowserRouter([
     ),
     children: [
       {
+        element: <PrivateRoute />,
+        children: [
+          {
+            path: 'change',
+            element: (
+              <div>
+                <ChargePage />
+                <ModalProvider />
+              </div>
+            ),
+          },
+          {
+            path: 'raffle-upload',
+            element: <RaffleUploadPage />,
+          },
+          {
+            path: 'review',
+            element: <WriteReview />,
+          },
+          {
+            path: 'mypage/address',
+            element: (
+              <>
+                <AddressSetPage />
+                <ModalProvider />
+              </>
+            ),
+          },
+          {
+            path: 'host-result',
+            element: (
+              <div>
+                <ResultPage />
+                <ModalProvider />
+              </div>
+            ),
+          },
+          {
+            path: 'mypage/following-list',
+            element: <FollowingList />,
+          },
+          {
+            path: 'mypage/setting',
+            element: <Setting />,
+          },
+          {
+            path: 'mypage',
+            element: <MyProfilePage />,
+          },
+          {
+            path: 'mypage/public-information-set',
+            element: <SetOpenInfoPage />,
+          },
+          {
+            path: 'mypage/my-review',
+            element: <MyReview />,
+          },
+          {
+            path: 'mypage/payment',
+            element: <Payment />,
+          },
+          {
+            path: 'user/:userId',
+            element: <UserProfilePage />,
+          },
+          {
+            path: 'winner-page',
+            element: <WinnerPage />,
+          },
+        ]
+      },
+      {
         path: '',
         element: (
           <div>
@@ -43,19 +116,6 @@ const router = createBrowserRouter([
             <ModalProvider />
           </div>
         ),
-      },
-      {
-        path: 'change',
-        element: (
-          <div>
-            <ChargePage />
-            <ModalProvider />
-          </div>
-        ),
-      },
-      {
-        path: 'raffle-upload',
-        element: <RaffleUploadPage />,
       },
       {
         path: 'raffles/:type', // 래플 상세보기
@@ -73,32 +133,6 @@ const router = createBrowserRouter([
             <KakaoRedirect />
             <ModalProvider />
           </div>
-        ),
-      },
-      {
-        path: 'review',
-        element: <WriteReview />,
-      },
-      {
-        path: 'address',
-        element: (
-          <>
-            <AddressSetPage />
-            <ModalProvider />
-          </>
-        ),
-      },
-      {
-        path: 'review',
-        element: <WriteReview />,
-      },
-      {
-        path: 'mypage/address',
-        element: (
-          <>
-            <AddressSetPage />
-            <ModalProvider />
-          </>
         ),
       },
       {
@@ -123,49 +157,8 @@ const router = createBrowserRouter([
         element: <CategoryResultPage />,
       },
       {
-        path: 'host-result',
-        element: (
-          <div>
-            <ResultPage />
-            <ModalProvider />
-          </div>
-        ),
-      },
-      {
-        path: 'mypage/following-list',
-        element: <FollowingList />,
-      },
-      {
-        path: 'mypage/setting',
-        element: <Setting />,
-      },
-      {
-        path: 'mypage',
-        element: <MyProfilePage />,
-      },
-      {
-        path: 'mypage/public-information-set',
-        element: <SetOpenInfoPage />,
-      },
-      {
-        path: 'mypage/my-review',
-        element: <MyReview />,
-      },
-      {
-        path: 'mypage/payment',
-        element: <Payment />,
-      },
-      {
-        path: 'user/:userId',
-        element: <UserProfilePage />,
-      },
-      {
         path: 'ask/:type',
         element: <AskPage />,
-      },
-      {
-        path: 'winner-page',
-        element: <WinnerPage />,
       },
     ],
   },

--- a/src/services/PrivateRoute.tsx
+++ b/src/services/PrivateRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext"
+
+const PrivateRoute = () => {
+  const {isAuthenticated} = useAuth();
+  
+  // 현재 URL 확인
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    alert("개인회원 로그인 후 이용해주세요.");
+    // ✅ 메인 페이지로 이동
+    // ❎ 로그인 모달 열기
+    return <Navigate to="/" state={{ from: location }} />;
+  }
+
+  // 로그인 상태라면 원래 컴포넌트 렌더링
+  return <Outlet />;
+};
+
+export default PrivateRoute;

--- a/src/services/PrivateRoute.tsx
+++ b/src/services/PrivateRoute.tsx
@@ -3,15 +3,12 @@ import { useAuth } from "../context/AuthContext"
 
 const PrivateRoute = () => {
   const {isAuthenticated} = useAuth();
-  
-  // 현재 URL 확인
-  const location = useLocation();
 
   if (!isAuthenticated) {
     alert("개인회원 로그인 후 이용해주세요.");
     // ✅ 메인 페이지로 이동
     // ❎ 로그인 모달 열기
-    return <Navigate to="/" state={{ from: location }} />;
+    return <Navigate to="/" />;
   }
 
   // 로그인 상태라면 원래 컴포넌트 렌더링


### PR DESCRIPTION
## 📑 이슈 번호
close #144

## ✨️ 작업 내용
로그인하지 않은 상태에서 로그인 필요한 페이지 URL로 접근 제한


## 💙 코멘트
현재 로그인 페이지가 아닌 로그인 모달을 사용 중이라, 로그인 후 곧바로 이동하려던 페이지로 리다이렉트가 불가능하여 alert 창 발생 후 홈 화면으로 리다이렉트 되도록 하였습니다.
추가로 로그인이 필요한데 PrivateRoute에 들어가지 않은 페이지가 있거나, 회원만 이용 가능한 페이지가 추가될 경우 라우터 경로에 추가 부탁드립니다.


## 📸 구현 결과
