### PR TITLE
Fix: getFormatTime 함수 수정

### DIFF
--- a/src/utils/formateTime.ts
+++ b/src/utils/formateTime.ts
@@ -1,7 +1,16 @@
 export const getFormatTime = (seconds: number): string => {
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const remainingSeconds = seconds % 60;
+  const ONE_DAY = 86400;
+  const ONE_HOUR = 3600;
+  const ONE_MINUTE = 60;
+
+  if (seconds > ONE_DAY) {
+    const days = Math.floor(seconds / ONE_DAY);
+    return `${days}일`;
+  }
+
+  const hours = Math.floor(seconds / ONE_HOUR);
+  const minutes = Math.floor((seconds % ONE_HOUR) / ONE_MINUTE);
+  const remainingSeconds = seconds % ONE_MINUTE;
 
   if (hours > 0) {
     return `${hours}시간 ${minutes}분 ${remainingSeconds}초`;


### PR DESCRIPTION
## 📑 이슈 번호
close#155

## ✨️ 작업 내용

- getFormatTime 함수 수정
    - 1일(86400초) 이상인 경우, n일 형식으로 반환


## 💙 코멘트

- `const One_Day` : 1일을 초 단위로 상수 선언 → 단위간 변환을 쉽게
    - `if (seconds > ONE_DAY)` : 초가 86400(=1일)보다 크면 → “일”로 표현
    - `Math.floor` : 소수점 버리고 정수로 만들어주는 함수
    - 다만, 24분 0분 0초 까진 나오고 → 이후로는 1일


## 📸 구현 결과
<img width="221" alt="스크린샷 2025-04-03 22 20 57" src="https://github.com/user-attachments/assets/ba0e5740-1147-4e6a-9010-fd0f2e4e1f7d" />
