### PR TITLE
Fix: footer 수정 #162

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -85,7 +85,7 @@ const FooterContainer = styled.footer`
 `;
 
 const FooterContent = styled.div`
-  width: 85%;
+  width: 80%;
   margin: 0 auto;
   display: flex;
   flex-direction: column;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC = () => {
 
   return (
     <FooterContainer>
-      <FooterContent>
+      <FooterContent withTopBorder>
       <Menu>
         {menuItems.map((item, index) => (
           <MenuItem
@@ -79,8 +79,7 @@ const FooterContainer = styled.footer`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border-top: 1px solid #eee;
-  margin: 0 auto;
+  margin: 202px auto 0;
   position: relative;
 `;
 
@@ -93,12 +92,18 @@ const FooterContent = styled.div`
   color: #8F8E94;
   font-size: 13px;
   box-sizing: border-box;
+  ${({ withTopBorder }) =>
+    withTopBorder &&
+    `
+    border-top: 1px solid #eee;
+  `}
 `;
 
 const Menu = styled.ul`
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  margin-top: -16px;
   margin-bottom: 32px;
 `;
 
@@ -181,7 +186,7 @@ const DividerLine = styled.div`
   position: absolute;
   bottom: 130px;
   left: 0;
-  width: 100%;
+  width: 100vw;
   height: 1px;
   background-color: #ddd;
   margin-top: 40px;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,8 @@ const Footer: React.FC = () => {
 
   return (
     <FooterContainer>
-      <FooterContent withTopBorder>
+      <DividerLine />
+      <FooterContent>
       <Menu>
         {menuItems.map((item, index) => (
           <MenuItem
@@ -44,8 +45,6 @@ const Footer: React.FC = () => {
           </CustomerCenter>
         </InfoSection>
       </FooterContent>
-
-      <DividerLine />
 
       <FooterContent>
         <FooterBottom>
@@ -92,18 +91,24 @@ const FooterContent = styled.div`
   color: #8F8E94;
   font-size: 13px;
   box-sizing: border-box;
-  ${({ withTopBorder }) =>
-    withTopBorder &&
-    `
-    border-top: 1px solid #eee;
-  `}
+`;
+
+const DividerLine = styled.div`
+  position: absolute;
+  top: 7px;
+  left: 50%;
+  width: 100vw;
+  margin: 0 auto 16px auto;
+  transform: translateX(-50%); //화면 넓이에 맞춰서 선이 이어지도록
+  height: 1px;
+  background-color: #ddd;
+  margin-bottom: 16px;
 `;
 
 const Menu = styled.ul`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  margin-top: -16px;
   margin-bottom: 32px;
 `;
 
@@ -180,17 +185,6 @@ const Spacer = styled.div`
 const Line = styled.div`
   font-size: 13px;
   line-height: 27px;
-`;
-
-const DividerLine = styled.div`
-  position: absolute;
-  bottom: 130px;
-  left: 0;
-  width: 100vw;
-  height: 1px;
-  background-color: #ddd;
-  margin-top: 40px;
-  margin-bottom: 40px;
 `;
 
 const FooterBottom = styled.div`


### PR DESCRIPTION
## 📑 이슈 번호
close#162

## ✨️ 작업 내용

- 좌우 여백 조정
- 상단 여백 추가
- 구분선 위치 조정

## 💙 코멘트

```
`const DividerLine = styled.div
    position: absolute;
    top: 7px;
    left: 50%;
    width: 100vw;
    margin: 0 auto 16px auto;
    transform: translateX(-50%); //화면 넓이에 맞춰서 선이 이어지도록
    height: 1px;
    background-color: #ddd;
    margin-bottom: 16px;
  `;
```

DividerLine의 경우, 부모 컴포넌트(FooterContent or FooterContainer)에 맞춰 width: 100%를 사용하면 선의 길이가 제한되어 좌우로 충분히 길게 이어지지 않더라구요.

따라서 width: 100vw를 사용해 화면 전체 너비에 맞추고,
left: 50% + transform: translateX(-50%) 조합으로 정확히 가운데 정렬되도록 처리했습니다.
이렇게 하면 콘텐츠 너비와 상관없이 선이 브라우저 전체 가로 길이에 맞췄습니다.

## 📸 구현 결과
<img width="700" alt="스크린샷 2025-04-12 02 46 47" src="https://github.com/user-attachments/assets/43eb8e1b-775e-4c0f-afb4-9b2815b592ea" />
